### PR TITLE
Allow use an environment-supplied API token

### DIFF
--- a/lib/slacky/config.rb
+++ b/lib/slacky/config.rb
@@ -24,7 +24,7 @@ module Slacky
     end
 
     def slack_api_token
-      @config[:slack_api_token]
+      ENV['SLACK_API_TOKEN'] || @config[:slack_api_token]
     end
 
     def slack_reject_channels


### PR DESCRIPTION
Problem: It's hard to have a `$HOME/.botname/config.yml` on Heroku
